### PR TITLE
Feature fe calendar

### DIFF
--- a/Front-end/schedular/src/Pages/Calendar.tsx
+++ b/Front-end/schedular/src/Pages/Calendar.tsx
@@ -157,8 +157,18 @@ const Calendar = () =>{
     }
   };
 
-  const _getEvents = async (events: EventSourceInput[]) => {
-    setEvtState(events.map(el => {return { ...el, 'start': el.startDate, 'end': el.endDate}}));
+  const _getEvents = async (newEvents: EventSourceInput[]) => {
+    setEvtState(prevState => {
+      const filteredEvents = newEvents.filter(newEvent =>
+        prevState.every(prevEvent => prevEvent.scheduleId !== newEvent.scheduleId)
+      );
+      const updatedEvents = [...prevState, ...filteredEvents];
+      return updatedEvents.map(event => ({
+        ...event,
+        'start': event.startDate,
+        'end': event.endDate
+      }));
+    });
   }
 
   // modal
@@ -227,7 +237,7 @@ const Calendar = () =>{
                     const nextDate = currentDate || new Date();
                     const nextMonth = currentMonth + 1;
                     const nextYear = currentYear; 
-                    
+
                     const currentView = calendarApi?.view;
                     if (currentView?.type === 'dayGridMonth') {
                       calendarApi?.gotoDate(new Date(nextYear, nextMonth));
@@ -240,13 +250,13 @@ const Calendar = () =>{
                       nextDate.setDate(nextDate.getDate() + 1);
                       calendarApi?.gotoDate(nextDate);
                     }
-
-                    if(nextDate.getMonth() !== currentMonth){
-                      let nextMonth = nextDate.getMonth();
-                      const new_M= (nextMonth + 1).toString().length === 1 ? `0${nextMonth+1}` : `${nextMonth-1}`;
+                    if(nextDate.getMonth() !== nextMonth){
+                      let new_M = (nextMonth+1).toString().length === 1 ? `0${nextMonth+1}` : `${nextMonth+1}`;
+                      const new_Y = Number(new_M)>12 ? (nextYear+1).toString(): nextYear.toString();
+                      if(nextMonth >= 12)  new_M = '01';
                       setMonth(new_M);
-                      setYear(nextYear.toString());
-                      performGetRequest(nextYear.toString(), new_M);
+                      setYear(new_Y);
+                      performGetRequest(new_Y.toString(), new_M);
                     }
                   },
                 },
@@ -274,12 +284,15 @@ const Calendar = () =>{
                       calendarApi?.gotoDate(preDate);
                     }
 
-                    if(preDate.getMonth() !== currentMonth) { 
-                      let preMonth = preDate.getMonth();
-                      const new_Month = (preMonth + 1).toString().length === 1 ? `0${preMonth+1}` : `${preMonth-1}`;
+                    if(preDate.getMonth() !== preMonth) {
+                      console.log("preMonth",preMonth+1);
+                      let new_Month = (preMonth+1).toString().length === 1 ? `0${preMonth+1}` : `${preMonth+1}`;
+                      console.log(new_Month);
+                      const new_Y = Number(new_Month) < 1 ? (preYear-1).toString(): preYear.toString();
+                      if(preMonth < 0 )  new_Month = '12';
                       setMonth(new_Month);
-                      setYear(preYear.toString());
-                      performGetRequest(preYear.toString(), new_Month);
+                      setYear(new_Y.toString());
+                      performGetRequest(new_Y.toString(), new_Month);
                     }
                   }
                 }

--- a/Front-end/schedular/src/interfaces/CalendarState.ts
+++ b/Front-end/schedular/src/interfaces/CalendarState.ts
@@ -23,7 +23,7 @@ interface EventSourceInput{
     dday?:string,
     color?:string,
     complete?:string,
-    imageurl?:string|HTMLImageElement|File,
+    imageurl?:string,
 }
 
 interface Events extends Array<EventSourceInput> {};

--- a/Front-end/schedular/src/interfaces/CalendarState.ts
+++ b/Front-end/schedular/src/interfaces/CalendarState.ts
@@ -10,6 +10,7 @@ interface ModalToggle{
 //subjectScheduleType : 과제,시험,발표 (과목)
 //type : personal(개인), subject(과목)
 interface EventSourceInput{
+    scheduleId?: string,
     title: string, 
     startDate: string, 
     endDate: string, 


### PR DESCRIPTION
* 기존 월 이동에서 주,일 이동도 가능하게 커스텀버튼 수정.
* 월간이동으로 년도가 바뀔때 month와 year을 재설정

![image](https://github.com/CSID-DGU/2023-1-OSSProj-NoQuestionMark-2/assets/79756267/88d82f69-dd17-4d20-845a-a2a07c9958e2)

* 기존 : 월간이동 시, 이벤트가 업데이트 된다. 따라서 할 일 보기가 해당하는 달에만 한정된다.
* 수정 : 월간이동 시, 매번 새롭게 이벤트를 주는 것이 아니라 이벤트의 id가 다른 것만 기존것에 추가하는 방법으로 변경. 할일보기가 업데이트가 되어 사라지는 것을 막음